### PR TITLE
Restore missing test to verify JSON output

### DIFF
--- a/test/input_4.output
+++ b/test/input_4.output
@@ -1,0 +1,258 @@
+{
+    "MeanFlow": 20630563.600762308, 
+    "monthly": [
+        {
+            "AvEvapoTrans": 0.38858115246356872, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 6.8926666666666669, 
+            "AvRunoff": 0.53710130955237578, 
+            "AvGroundWater": 5.2545457730522722, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 5.7849312864452873
+        }, 
+        {
+            "AvEvapoTrans": 0.54121623122451346, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 6.0613333333333337, 
+            "AvRunoff": 0.61703454835906979, 
+            "AvGroundWater": 4.5508401967685499, 
+            "AvPtSrcFlow": 0.00025670024315814998, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 5.1611314453707777
+        }, 
+        {
+            "AvEvapoTrans": 1.771169693471139, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 8.2933333333333312, 
+            "AvRunoff": 0.7310688156711781, 
+            "AvGroundWater": 6.1852969384773395, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 6.9096499579891573
+        }, 
+        {
+            "AvEvapoTrans": 3.4957251176285959, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 9.4880000000000013, 
+            "AvRunoff": 0.66181331240562047, 
+            "AvGroundWater": 5.8508950265852633, 
+            "AvPtSrcFlow": 0.00027503597481230301, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 6.5059833749656963
+        }, 
+        {
+            "AvEvapoTrans": 7.3839154808176737, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 9.1286666666666658, 
+            "AvRunoff": 0.11112832291909575, 
+            "AvGroundWater": 4.5395841599407536, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 4.6439966867004889
+        }, 
+        {
+            "AvEvapoTrans": 11.372901054151882, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 11.359333333333334, 
+            "AvRunoff": 0.4023372221853137, 
+            "AvGroundWater": 3.0532047175237946, 
+            "AvPtSrcFlow": 0.00027503597481230301, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 3.4488169756839206
+        }, 
+        {
+            "AvEvapoTrans": 13.046030626608976, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 10.854666666666667, 
+            "AvRunoff": 0.42375207037183438, 
+            "AvGroundWater": 1.4171379624711951, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 1.8341742366836691
+        }, 
+        {
+            "AvEvapoTrans": 9.855966464373644, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 9.3280000000000012, 
+            "AvRunoff": 0.20181444425536124, 
+            "AvGroundWater": 0.91922019028359003, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 1.1143188383795908
+        }, 
+        {
+            "AvEvapoTrans": 6.4160892859699059, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 12.435333333333332, 
+            "AvRunoff": 0.85424250674850088, 
+            "AvGroundWater": 0.82695333522515224, 
+            "AvPtSrcFlow": 0.00027503597481230301, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 1.6744708779484656
+        }, 
+        {
+            "AvEvapoTrans": 3.4473154833975341, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 12.306666666666668, 
+            "AvRunoff": 2.0395048875065762, 
+            "AvGroundWater": 1.5856839777061222, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 3.6184730690533375
+        }, 
+        {
+            "AvEvapoTrans": 1.6705942642120437, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 7.6073333333333339, 
+            "AvRunoff": 0.22891105189164973, 
+            "AvGroundWater": 3.8596253851285494, 
+            "AvPtSrcFlow": 0.00027503597481230301, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 4.0818114729950121
+        }, 
+        {
+            "AvEvapoTrans": 0.69950343422288275, 
+            "AvTileDrain": 0.0, 
+            "AvPrecipitation": 9.0260000000000016, 
+            "AvRunoff": 0.86176306357288468, 
+            "AvGroundWater": 6.5700376297089003, 
+            "AvPtSrcFlow": 0.00028420384063937995, 
+            "AvWithdrawal": 0.0069999999999999975, 
+            "AvStreamFlow": 7.4250848971224244
+        }
+    ], 
+    "meta": {
+        "NRur": 10, 
+        "SedDelivRatio": 0.149, 
+        "NLU": 16, 
+        "NUrb": 6, 
+        "WxYrBeg": 2000, 
+        "NYrs": 15, 
+        "WxYrEnd": 2014
+    }, 
+    "MeanFlowPerSecond": 0.6541908802879981, 
+    "AreaTotal": 3952.0, 
+    "SummaryLoads": [
+        {
+            "Source": "Total Loads", 
+            "TotalN": 173586.74868105561, 
+            "TotalP": 8395.6579146152235, 
+            "Sediment": 2407902.8677433841, 
+            "Unit": "kg"
+        }, 
+        {
+            "Source": "Loading Rates", 
+            "TotalN": 43.923772439538361, 
+            "TotalP": 2.1244073670585082, 
+            "Sediment": 609.28716289053239, 
+            "Unit": "kg/ha"
+        }, 
+        {
+            "Source": "Mean Annual Concentration", 
+            "TotalN": 8.4140575139033782, 
+            "TotalP": 0.40695242636536605, 
+            "Sediment": 116.71532171105648, 
+            "Unit": "mg/l"
+        }, 
+        {
+            "Source": "Mean Low-Flow Concentration", 
+            "TotalN": 14.804110709397358, 
+            "TotalP": 1.3626915312075798, 
+            "Sediment": 304.3460842383692,
+            "Unit": "mg/l"
+        }
+    ], 
+    "Loads": [
+        {
+            "Source": "Hay/Pasture", 
+            "TotalN": 453.57856428940312, 
+            "TotalP": 114.81261901179309, 
+            "Sediment": 100302.43772592283
+        }, 
+        {
+            "Source": "Cropland", 
+            "TotalN": 6222.829631283309, 
+            "TotalP": 881.945338698569, 
+            "Sediment": 1696483.1493033222
+        }, 
+        {
+            "Source": "Wooded Areas", 
+            "TotalN": 80.784607841492317, 
+            "TotalP": 8.7527229706370449, 
+            "Sediment": 11150.3533168915
+        }, 
+        {
+            "Source": "Wetlands", 
+            "TotalN": 10.640524141742205, 
+            "TotalP": 0.64967631793961522, 
+            "Sediment": 200.58734669214468
+        }, 
+        {
+            "Source": "Open Land", 
+            "TotalN": 182.04507831320686, 
+            "TotalP": 17.54609792932213, 
+            "Sediment": 30213.322669806887
+        }, 
+        {
+            "Source": "Barren Areas", 
+            "TotalN": 0.0, 
+            "TotalP": 0.0, 
+            "Sediment": 0.0
+        }, 
+        {
+            "Source": "Low-Density Mixed", 
+            "TotalN": 31.375171699915892, 
+            "TotalP": 3.4655446071285301, 
+            "Sediment": 1404.524341001867
+        }, 
+        {
+            "Source": "Medium-Density Mixed", 
+            "TotalN": 142.50586217322834, 
+            "TotalP": 15.523650247755425, 
+            "Sediment": 5912.9401733380037
+        }, 
+        {
+            "Source": "High-Density Mixed", 
+            "TotalN": 254.6913281393868, 
+            "TotalP": 27.744396187477783, 
+            "Sediment": 10567.807969370049
+        }, 
+        {
+            "Source": "Other Upland Areas", 
+            "TotalN": 30.238654482454763, 
+            "TotalP": 3.2791341225284558, 
+            "Sediment": 2815.7448970384444
+        }, 
+        {
+            "Source": "Farm Animals", 
+            "TotalN": 40140.021156308459, 
+            "TotalP": 6694.9321663995443, 
+            "Sediment": 0
+        }, 
+        {
+            "Source": "Stream Bank Erosion", 
+            "TotalN": 507.0, 
+            "TotalP": 136.0, 
+            "Sediment": 548852.0
+        }, 
+        {
+            "Source": "Subsurface Flow", 
+            "TotalN": 124504.12969043053, 
+            "TotalP": 490.44336657252757, 
+            "Sediment": 0
+        }, 
+        {
+            "Source": "Point Sources", 
+            "TotalN": 7.5244614599999986, 
+            "TotalP": 0.56320154999999994, 
+            "Sediment": 0
+        }, 
+        {
+            "Source": "Septic Systems", 
+            "TotalN": 1019.383950492498, 
+            "TotalP": 0.0, 
+            "Sediment": 0
+        }
+    ]
+}

--- a/test/test_gms_writer.py
+++ b/test/test_gms_writer.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import unittest
+import json
 from StringIO import StringIO
 from itertools import izip
 
@@ -11,6 +12,23 @@ from gwlfe import gwlfe
 
 
 class TestGMSWriter(unittest.TestCase):
+    """
+    Tests model generated output versus known
+    static output.
+    """
+    def test_generated_output_matches_static_output(self):
+        """
+        Test generated output using the sample GMS, input_4.gms
+        versus static output generated using the same file.
+        """
+        input_file = open('test/input_4.gms', 'r')
+        z = Parser.GmsReader(input_file).read()
+        generated_output = gwlfe.run(z)
+
+        static_output = json.load(open('test/input_4.output', 'r'))
+
+        self.assertEqual(generated_output, static_output)
+
     def test_gms_writer(self):
         """
         Test that GmsWriter is able to replicate the sample GMS created


### PR DESCRIPTION
This test is present in the original repo: https://github.com/WikiWatershed/gwlf-e/blob/02077a0314c4d90f64fcad48abe30d2d034df840/test/test_output.py#L15-L30, and was at some point removed from this version. It ensures that the JSON output is the same as before.

List of changes to this file:

```git
$ git log --oneline --follow -- test/test_output.py
```

a272098 added a decorator to dynamically import precompiled libraries
3a4334c finished extracting initsnow
a14bfb9 skipped all failing tests
15339ab finished moving GRStreamN (lots of loose ends)
bb456d2 added extra statements to test failures when iterating over the month
88cb81f converted avprecipitation
299991b wrote tests for ET and precipitation
5fab6c5 progress commit for ET (not passing tests)
5662847 added tests for output file
305452b Add GmsWriter unit test
9ff37dc Add output unit test

Currently, adding this test results in failure. This test must pass before the new version can be merged.