### PR TITLE
Add ability for model to run without requiring a compiler

### DIFF
--- a/gwlfe/BMPs/Stream/UrbLoadRed_inner.py
+++ b/gwlfe/BMPs/Stream/UrbLoadRed_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('UrbLoadRed_inner_compiled')
+try:
+    cc = CC('UrbLoadRed_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('UrbLoadRed_inner',

--- a/gwlfe/Input/WaterBudget/AMC5_yesterday_inner.py
+++ b/gwlfe/Input/WaterBudget/AMC5_yesterday_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('AMC5_yesterday_inner_compiled')
+try:
+    cc = CC('AMC5_yesterday_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('AMC5_yesterday_inner', '(int64, int64[:,::1], float64[::1], float64[:,:,::1])')

--- a/gwlfe/Input/WaterBudget/DeepSeep_inner.py
+++ b/gwlfe/Input/WaterBudget/DeepSeep_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('DeepSeep_inner_compiled')
+try:
+    cc = CC('DeepSeep_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('DeepSeep_inner', '(int64, float64, int64[:,::1], float64, float64, float64[:,:,::1])')
@@ -14,7 +18,7 @@ def DeepSeep_inner(NYrs, SatStor_0, DaysMonth, RecessionCoef, SeepCoef, percolat
         for i in range(12):
             for j in range(DaysMonth[Y][i]):
                 satstor[Y][i][j] = satstor_carryover
-                grflow[Y][i][j] = max(RecessionCoef * satstor[Y][i][j],1e-20)
+                grflow[Y][i][j] = max(RecessionCoef * satstor[Y][i][j], 1e-20)
                 deepseep[Y][i][j] = SeepCoef * satstor[Y][i][j]
                 satstor[Y][i][j] = satstor[Y][i][j] + percolation[Y][i][j] - grflow[Y][i][j] - deepseep[Y][i][j]
                 if satstor[Y][i][j] < 0:

--- a/gwlfe/Input/WaterBudget/InitSnowYesterday_inner.py
+++ b/gwlfe/Input/WaterBudget/InitSnowYesterday_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('InitSnowYesterday_inner_compiled')
+try:
+    cc = CC('InitSnowYesterday_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('InitSnowYesterday_inner', '(int64, int64[:,::1], int64, float64[:,:,::1], float64[:,:,::1])')

--- a/gwlfe/Input/WaterBudget/InitSnow_inner.py
+++ b/gwlfe/Input/WaterBudget/InitSnow_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('InitSnow_f_inner_compiled')
+try:
+    cc = CC('InitSnow_f_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('InitSnow_f_inner', '(int64, int64[:,::1], int64, float64[:,:,::1], float64[:,:,::1])')

--- a/gwlfe/Input/WaterBudget/Percolation_inner.py
+++ b/gwlfe/Input/WaterBudget/Percolation_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('Percolation_inner_compiled')
+try:
+    cc = CC('Percolation_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('Percolation_inner', '(int64, float64, int64[:,::1], float64, float64[:,:,::1], float64[:,:,::1])')

--- a/gwlfe/Input/WaterBudget/UnsatStor_inner.py
+++ b/gwlfe/Input/WaterBudget/UnsatStor_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('UnsatStor_inner_compiled')
+try:
+    cc = CC('UnsatStor_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('UnsatStor_inner', '(int64,int64[:,::1],float64,float64,float64[:,:,::1],float64[:,:,::1])')

--- a/gwlfe/MultiUse_Fxns/Discharge/AdjUrbanQTotal_inner.py
+++ b/gwlfe/MultiUse_Fxns/Discharge/AdjUrbanQTotal_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('AdjUrbanQTotal_inner_compiled')
+try:
+    cc = CC('AdjUrbanQTotal_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('AdjUrbanQTotal_inner',

--- a/gwlfe/MultiUse_Fxns/DummyCC.py
+++ b/gwlfe/MultiUse_Fxns/DummyCC.py
@@ -1,0 +1,6 @@
+class DummyCC(object):
+    """This is a decorator that can replace Numba CC if something goes wrong with importing the system compiler. This will allow the code to still run using pure python"""
+    def export(self, exported_name, sig):
+        def decorator(func):
+            return func #just a pass through
+        return decorator

--- a/gwlfe/MultiUse_Fxns/Runoff/CNumImperv_inner.py
+++ b/gwlfe/MultiUse_Fxns/Runoff/CNumImperv_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('CNumImperv_inner_compiled')
+try:
+    cc = CC('CNumImperv_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('CNumImperv_inner',

--- a/gwlfe/MultiUse_Fxns/Runoff/CNumPerv_inner.py
+++ b/gwlfe/MultiUse_Fxns/Runoff/CNumPerv_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('CNumPerv_inner_compiled')
+try:
+    cc = CC('CNumPerv_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('CNumPerv_inner',

--- a/gwlfe/MultiUse_Fxns/Runoff/CNum_inner.py
+++ b/gwlfe/MultiUse_Fxns/Runoff/CNum_inner.py
@@ -1,7 +1,11 @@
 from numba.pycc import CC
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('CNum_inner_compiled')
+try:
+    cc = CC('CNum_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('CNum_inner',

--- a/gwlfe/MultiUse_Fxns/Runoff/WashImperv_inner.py
+++ b/gwlfe/MultiUse_Fxns/Runoff/WashImperv_inner.py
@@ -4,7 +4,12 @@ from numba.pycc import CC
 from numpy import exp
 from numpy import zeros
 
-cc = CC('WashImperv_inner_compiled')
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
+
+try:
+    cc = CC('WashImperv_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('WashImperv_inner',

--- a/gwlfe/MultiUse_Fxns/Runoff/WashPerv_inner.py
+++ b/gwlfe/MultiUse_Fxns/Runoff/WashPerv_inner.py
@@ -3,8 +3,12 @@ import math
 from numba.pycc import CC
 from numpy import exp
 from numpy import zeros
+from gwlfe.MultiUse_Fxns.DummyCC import DummyCC
 
-cc = CC('WashPerv_inner_compiled')
+try:
+    cc = CC('WashPerv_inner_compiled')
+except RuntimeError:
+    cc = DummyCC()
 
 
 @cc.export('WashPerv_inner',


### PR DESCRIPTION
For some systems (especially Windows), installing a compiler and linking it to Numpy distutils can be annoying. If speed is not an issue, then a compiler should not be required to run the model.

The requirement stems from the use of number decorators. Since I'm not sure how to get rid of that and still maintain an easy installation, the solution I offer is to patch in a dummy class that allows the decorators to remain without having an effect on systems without a proper compiler.